### PR TITLE
Copy Update – macOS (Fixed)

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@ else if (navigator.appVersion.toLowerCase().indexOf("linux")!=-1 && navigator.ap
 
  <div class="download download-mac">
   <div class="button-container">
-   <a href="https://github.com/HelloZeroNet/ZeroBundle/raw/master/dist/ZeroBundle-mac-osx.zip" class="button button-outline">Download for Apple OS X</a><br>
+   <a href="https://github.com/HelloZeroNet/ZeroBundle/raw/master/dist/ZeroBundle-mac-osx.zip" class="button button-outline">Download for macOS</a><br>
    <small>9.5MB &middot; Unpack &middot; Run ZeroNet</small>
   </div>
   <div class="button-container" style="margin: 0px 10px">
@@ -62,7 +62,7 @@ else if (navigator.appVersion.toLowerCase().indexOf("linux")!=-1 && navigator.ap
 
  <div class="download download-oldmac">
   <div class="button-container">
-   <a href="https://github.com/HelloZeroNet/ZeroBundle/raw/master/dist/ZeroBundle-mac-osx.zip" class="button button-outline">Download for Apple OS X</a><br>
+   <a href="https://github.com/HelloZeroNet/ZeroBundle/raw/master/dist/ZeroBundle-mac-osx.zip" class="button button-outline">Download for macOS</a><br>
    <small>9.5MB &middot; Unpack &middot; Open Terminal application &middot; Drop ZeroNet on it</small>
   </div>
   <div class="button-container" style="margin: 0px 10px">


### PR DESCRIPTION
_Info:_
Updated Homepage with the following copy update:
- Changed all occurances of 'Apple OS X' to the newly named 'macOS'
