### PR TITLE
Fix regex to make `site:` part optional

### DIFF
--- a/go.html
+++ b/go.html
@@ -34,7 +34,7 @@
 
 <script>
 function getLandingSiteAddress(hash) {
-    var match = hash.match(/^#site:([A-Za-z0-9\.]+)$/i);
+    var match = hash.match(/^#(?:site:)?([A-Za-z0-9\.]+)$/i);
     if (match)
         return match[1]
 }


### PR DESCRIPTION
As this is now on a separate page, `site:` part of the hash shouldn't be really needed. So I make it optional.

This means that you can now use https://go.zeronet.io/#1BLogC9LN4oPDcruNz3qo1ysa133E9AGg8 as well as https://go.zeronet.io/#Site:1BLogC9LN4oPDcruNz3qo1ysa133E9AGg8.